### PR TITLE
Initial Rate Limiter (translated from Java to C#)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A (purposefully) Simple Rate Limiter Implementation
+# A (purposefully) Simple Rate Limiter Implementation
 
 For security applications, e.g. when exposing an API, a rate limiter can help mitigate flooding.
 
@@ -6,14 +6,16 @@ In order to use the least amount of instructions for this rate-limiting activity
 
 Having 100% branch coverage by unit tests should help ensure that the code can be used for actually making an API safer to expose. (It can not make your API safer, but if we avoid not limiting the rate of actual calls performed, we might at least not make it worse.)
 
-While the guava rate limiter has some cool ideas about behavior after lull periods, the default rate limiting algorithm seems to be SmoothBursty -- the behavior of which, as far as I can tell, is more easily implementend using the token bucket algorithm. (That "as far as I can tell" is also a motivation for this library -- the code is supposed to be so simple, that there is no question as to what it does.)
+While the guava rate limiter has some cool ideas about behavior after lull periods, the default rate limiting algorithm seems to be SmoothBursty -- the behavior of which, as far as I can tell, is more easily implemented using the token bucket algorithm. (That "as far as I can tell" is also a motivation for this library -- the code is supposed to be so simple, that there is no question as to what it does.)
 
 Also, I wanted to make the implementation simpler by separating concerns: the guava rate limiter mixes synchronization, waiting and the actual rate limiting algorithm in two classes (and some helpers), this project has
 
-    a rate limiter interface
-    an implementation using the token bucket algorithm (others should be possible)
+- a rate limiter interface
+- an implementation using the token bucket algorithm (others should be possible)
 
 these are not done yet:
 
-    an implementation of synchronization (making it thread safe in a way that seems to have obviously no errors, as opposed to no obvious errors)
-    a wrapper for waiting until tokens are available (which is interruptible, because I don't see why it should not)
+- an implementation of synchronization (making it thread safe in a way that seems to have obviously no errors, as opposed to no obvious errors)
+- a wrapper that makes it easier (and more correct) to implement asynchronous
+  rate-limiting with multiple processes consuming tokens
+- a wrapper for waiting until tokens are available

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+A (purposefully) Simple Rate Limiter Implementation
+
+For security applications, e.g. when exposing an API, a rate limiter can help mitigate flooding.
+
+In order to use the least amount of instructions for this rate-limiting activity, a simple rate limiter implementation using the token bucket algorithm is provided.
+
+Having 100% branch coverage by unit tests should help ensure that the code can be used for actually making an API safer to expose. (It can not make your API safer, but if we avoid not limiting the rate of actual calls performed, we might at least not make it worse.)
+
+While the guava rate limiter has some cool ideas about behavior after lull periods, the default rate limiting algorithm seems to be SmoothBursty -- the behavior of which, as far as I can tell, is more easily implementend using the token bucket algorithm. (That "as far as I can tell" is also a motivation for this library -- the code is supposed to be so simple, that there is no question as to what it does.)
+
+Also, I wanted to make the implementation simpler by separating concerns: the guava rate limiter mixes synchronization, waiting and the actual rate limiting algorithm in two classes (and some helpers), this project has
+
+    a rate limiter interface
+    an implementation using the token bucket algorithm (others should be possible)
+
+these are not done yet:
+
+    an implementation of synchronization (making it thread safe in a way that seems to have obviously no errors, as opposed to no obvious errors)
+    a wrapper for waiting until tokens are available (which is interruptible, because I don't see why it should not)

--- a/RateLimiter/IRateLimiter.cs
+++ b/RateLimiter/IRateLimiter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace RateLimiter
+﻿namespace RateLimiter
 {
     /**
      * An IRateLimiter provides a way to rate limit events. Each event is assigned 
@@ -40,7 +38,7 @@ namespace RateLimiter
      * Constants for IRateLimiter implementations: when a request for permits can
      * not be satisfied, WaitImpossible will be returned instead.
      */
-    public class RateLimiterConstants
+    public static class RateLimiterConstants
     {
         public const long WaitImpossible = long.MaxValue;
     }

--- a/RateLimiter/IRateLimiter.cs
+++ b/RateLimiter/IRateLimiter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace RateLimiter
+{
+    /**
+     * An IRateLimiter provides a way to rate limit events. Each event is assigned 
+     * an amount of some imaginary resource and the IRateLimiter restricts the 
+     * amount per time that can be consumed.
+     * 
+     * If no amount is specified, each event is worth an amount of 1.0 and the 
+     * configuration of the specific IRateLimiter implementation would specify 
+     * the rate at which consumable amount is created.
+     * 
+     * The utility interface ITimeSource should be used by implementations
+     * to make them testable.
+     * 
+     * If a rate limiter will never allow an event of a certain amount, it
+     * will return a waiting time of RateLimiterConstants.WaitImpossible
+     * from WaitTimeForAmount() and ConsumeAmount() will always return false.
+     * 
+     * This type of rate limiter can be used to rate limit incoming API calls
+     * by dropping calls that exceed the limit. It can also be used to limit
+     * outgoing API calls by waiting the time returned by WaitTimeForAmount(),
+     * since this call does not consume the amount, this can only work properly
+     * in single-threaded applications when using implementations of this 
+     * interface. For multi-threaded operation the rate limiter needs to be
+     * locked when checking if the required amount of permits is available.
+     * 
+     * @author Harald Niesche
+     *
+     */
+    
+    public interface IRateLimiter
+    {
+        bool ConsumeAmount(double numPermits = 1.0);
+        long WaitTimeForAmount(double numPermits = 1.0);
+    }
+
+    /**
+     * Constants for IRateLimiter implementations: when a request for permits can
+     * not be satisfied, WaitImpossible will be returned instead.
+     */
+    public class RateLimiterConstants
+    {
+        public const long WaitImpossible = long.MaxValue;
+    }
+
+    /**
+     * Utility interface for testability: IRateLimiter instances should use an
+     * implementation of this interface to obtain the current time.
+     */
+    public interface ITimeSource
+    {
+        /**
+         * Current Time in Ticks -- 100ns intervals since 0001-01-01_00:00
+         */
+        long CurrentTimeTicks();
+    }
+}

--- a/RateLimiter/RateLimiter.csproj
+++ b/RateLimiter/RateLimiter.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/RateLimiter/RateLimiterTokenBucket.cs
+++ b/RateLimiter/RateLimiterTokenBucket.cs
@@ -57,7 +57,8 @@ namespace RateLimiter
             if (waitTime > RateLimiterConstants.WaitImpossible) {
                 return RateLimiterConstants.WaitImpossible;
             }
-            return (long)waitTime;        }
+            return (long)waitTime;        
+          }
         
         private void _updateAmount()
         {

--- a/RateLimiter/RateLimiterTokenBucket.cs
+++ b/RateLimiter/RateLimiterTokenBucket.cs
@@ -17,7 +17,7 @@ namespace RateLimiter
             return new RateLimiterTokenBucket(ratePerSecond, maxAmount, Math.Min(initAmount, maxAmount), timeSource);
         }
 
-        RateLimiterTokenBucket(double ratePerSecond, double maxAmount, double initAmount, ITimeSource timeSource)
+        protected RateLimiterTokenBucket(double ratePerSecond, double maxAmount, double initAmount, ITimeSource timeSource)
         {
             _ratePerTick = ratePerSecond / TicksPerSecond;
             _maxAmount = maxAmount;

--- a/RateLimiter/RateLimiterTokenBucket.cs
+++ b/RateLimiter/RateLimiterTokenBucket.cs
@@ -4,9 +4,7 @@ namespace RateLimiter
 {
     public class RateLimiterTokenBucket : IRateLimiter
     {
-        // Number of 100ns ticks per time unit (copied from DateTime)
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
+
         
         public static RateLimiterTokenBucket CreateInstance(
             double ratePerSecond, 
@@ -19,7 +17,7 @@ namespace RateLimiter
 
         protected RateLimiterTokenBucket(double ratePerSecond, double maxAmount, double initAmount, ITimeSource timeSource)
         {
-            _ratePerTick = ratePerSecond / TicksPerSecond;
+            _ratePerTick = ratePerSecond / TimeSpan.TicksPerSecond;
             _maxAmount = maxAmount;
             _currentAmount = initAmount;
             _timeSource = timeSource ?? S_DefaultTimeSource;

--- a/RateLimiter/RateLimiterTokenBucket.cs
+++ b/RateLimiter/RateLimiterTokenBucket.cs
@@ -12,7 +12,11 @@ namespace RateLimiter
             double initAmount = 0.0,
             ITimeSource timeSource = default(ITimeSource)
         ) {
-            return new RateLimiterTokenBucket(ratePerSecond, maxAmount, Math.Min(initAmount, maxAmount), timeSource);
+            return new RateLimiterTokenBucket(
+                ratePerSecond: ratePerSecond, 
+                maxAmount: maxAmount, 
+                initAmount: Math.Min(initAmount, maxAmount), 
+                timeSource: timeSource);
         }
 
         protected RateLimiterTokenBucket(double ratePerSecond, double maxAmount, double initAmount, ITimeSource timeSource)

--- a/RateLimiter/RateLimiterTokenBucket.cs
+++ b/RateLimiter/RateLimiterTokenBucket.cs
@@ -1,0 +1,91 @@
+using System;
+
+namespace RateLimiter
+{
+    public class RateLimiterTokenBucket : IRateLimiter
+    {
+        // Number of 100ns ticks per time unit (copied from DateTime)
+        private const long TicksPerMillisecond = 10000;
+        private const long TicksPerSecond = TicksPerMillisecond * 1000;
+        
+        public static RateLimiterTokenBucket CreateInstance(
+            double ratePerSecond, 
+            double maxAmount, 
+            double initAmount = 0.0,
+            ITimeSource timeSource = default(ITimeSource)
+        ) {
+            return new RateLimiterTokenBucket(ratePerSecond, maxAmount, Math.Min(initAmount, maxAmount), timeSource);
+        }
+
+        RateLimiterTokenBucket(double ratePerSecond, double maxAmount, double initAmount, ITimeSource timeSource)
+        {
+            _ratePerTick = ratePerSecond / TicksPerSecond;
+            _maxAmount = maxAmount;
+            _currentAmount = initAmount;
+            _timeSource = timeSource ?? S_DefaultTimeSource;
+            _lastTimeTicks = _timeSource.CurrentTimeTicks();
+        }
+        
+        public bool ConsumeAmount(double numPermits = 1.0)
+        {
+            _updateAmount();
+            bool success = _currentAmount >= numPermits;
+            if (success) {
+                _currentAmount -= numPermits;
+            }
+            return success;
+        }
+
+        public long WaitTimeForAmount(double numPermits = 1.0)
+        {
+            if (numPermits <= _currentAmount) {
+                return 0;
+            }
+            _updateAmount();
+
+            if (numPermits <= _currentAmount) {
+                return 0;
+            }
+            if (numPermits > _maxAmount) {
+                return RateLimiterConstants.WaitImpossible;
+            }
+    
+            double lack = numPermits - _currentAmount;
+            double waitTime = Math.Ceiling(lack / _ratePerTick);
+            if (waitTime > RateLimiterConstants.WaitImpossible) {
+                return RateLimiterConstants.WaitImpossible;
+            }
+            return (long)waitTime;        }
+        
+        private void _updateAmount()
+        {
+            long now = _timeSource.CurrentTimeTicks();
+            long deltaTicks = now - _lastTimeTicks;
+            if (deltaTicks > 0) {
+                double adjust = deltaTicks * _ratePerTick;
+                adjust += _currentAmount;
+                _currentAmount = Math.Min(adjust, _maxAmount);
+                _lastTimeTicks = now;
+            }
+        }
+
+        
+        private readonly double _ratePerTick;
+        private readonly double _maxAmount;
+        private double _currentAmount;
+        private long   _lastTimeTicks;
+  
+        private readonly ITimeSource _timeSource;
+  
+        private static readonly ITimeSource S_DefaultTimeSource = new TimeSourceSystemTicks();
+
+        private class TimeSourceSystemTicks : ITimeSource
+        {
+            public long CurrentTimeTicks()
+            {
+                return DateTime.Now.Ticks;
+            }
+        }
+    }
+    
+}

--- a/RateLimiterTests/RateLimiterTests.csproj
+++ b/RateLimiterTests/RateLimiterTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RateLimiter\RateLimiter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RateLimiterTests/TestRateLimiter.cs
+++ b/RateLimiterTests/TestRateLimiter.cs
@@ -94,39 +94,4 @@ namespace RateLimiterTests
             Assert.AreEqual(RateLimiterConstants.WaitImpossible, rateLimiter.WaitTimeForAmount(1e9));
         }
     }
-
-
-    class TimeSourceZero : ITimeSource
-    {
-        public long CurrentTimeTicks()
-        {
-            return 0L;
-        }
-    }
-    
-    class TimeSourceAdjustable : ITimeSource
-    {
-
-        public TimeSourceAdjustable(long startTime = 0L)
-        {
-            _currentTime = startTime;
-        }
-
-        public long CurrentTimeTicks()
-        {
-            return _currentTime;
-        }
-
-        public void AddTimeTicks(long ticks)
-        {
-            _currentTime += ticks;
-        }
-
-        public void SetTime(long ticks)
-        {
-            _currentTime = ticks;
-        }
-        
-        private long _currentTime;
-    }
 }

--- a/RateLimiterTests/TestRateLimiter.cs
+++ b/RateLimiterTests/TestRateLimiter.cs
@@ -1,0 +1,159 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RateLimiter;
+
+namespace RateLimiterTests
+{
+
+    [TestClass]
+    public class TestRateLimiter
+    {
+        // Number of 100ns ticks per time unit (copied from DateTime)
+        private const long S_TicksPerMillisecond = 10000;
+        private const long S_TicksPerSecond = S_TicksPerMillisecond * 1000;
+
+        private long TicksPerSecond(double seconds)
+        {
+            return (long) Math.Ceiling(seconds * (double)S_TicksPerSecond);
+        }
+
+        [TestMethod]
+        public void TestTicksPerSecondFractions()
+        {
+            Assert.AreEqual(
+                TicksPerSecond(0.01+0.99), 
+                TicksPerSecond(0.01)+TicksPerSecond(0.99)
+            );
+        }
+
+        [TestMethod]
+        public void TestRateLimiterCreateWorksWithoutInitAmountAndTimeSource()
+        {
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0);
+            
+            Assert.IsNotNull(rateLimiter);
+            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount(1.0));
+            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount());
+            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount(1.0));
+            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount());
+        }
+        
+        /*
+        [TestMethod]
+        public void TestRateLimiterCreateWorksWithoutTimeSource()
+        {
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 0.0);
+            
+            Assert.IsNotNull(rateLimiter);
+            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount(1.0));
+            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount());
+            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount(1.0));
+            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount());
+        }
+
+        [TestMethod]
+        public void TestRateLimiterCreateWorksWithTimeSource()
+        {
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 0.0, new TimeSourceZero());
+            
+            Assert.IsNotNull(rateLimiter);
+            Assert.AreEqual(TicksPerSecond(1), rateLimiter.WaitTimeForAmount(1.0));
+            Assert.AreEqual(TicksPerSecond(1), rateLimiter.WaitTimeForAmount());
+        }
+        */
+        
+        [TestMethod]
+        public void TestRateLimiterGivesOutInitAmount()
+        {
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 1.0, new TimeSourceZero());
+            
+            Assert.IsTrue(rateLimiter.ConsumeAmount(1.0));
+        }
+
+        [TestMethod]
+        public void TestRateLimiterDoesNotWaitForInitAmount()
+        {
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 1.0, new TimeSourceZero());
+            
+            Assert.AreEqual(0, rateLimiter.WaitTimeForAmount(1.0));
+            Assert.AreEqual(0, rateLimiter.WaitTimeForAmount());
+        }
+
+        [TestMethod]
+        public void TestRateLimiterConsumesAdditionalAmount()
+        {
+            var timeSource = new TimeSourceAdjustable(0);
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 1.0, timeSource);
+            
+            Assert.AreEqual(TicksPerSecond(0), rateLimiter.WaitTimeForAmount(1.0));
+            Assert.AreEqual(TicksPerSecond(1), rateLimiter.WaitTimeForAmount(2.0));
+
+            timeSource.AddTimeTicks(TicksPerSecond(0.999));
+
+            Assert.AreEqual(TicksPerSecond(0), rateLimiter.WaitTimeForAmount(1.0));
+            Assert.AreEqual(TicksPerSecond(0.001), rateLimiter.WaitTimeForAmount(2.0));
+
+
+            timeSource.SetTime(TicksPerSecond(1));
+
+            Assert.AreEqual(TicksPerSecond(0), rateLimiter.WaitTimeForAmount(1.0));
+            Assert.AreEqual(TicksPerSecond(0), rateLimiter.WaitTimeForAmount(2.0));
+        }
+
+        [TestMethod]
+        public void TestRateLimiterWontGiveOutMoreThanMaxAmount()
+        {
+            var timeSource = new TimeSourceAdjustable(0);
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 6.0, timeSource);
+
+            Assert.AreEqual(RateLimiterConstants.WaitImpossible, rateLimiter.WaitTimeForAmount(6.0));
+            Assert.IsFalse(rateLimiter.ConsumeAmount(6.0));
+        }
+
+        
+        
+        [TestMethod]
+        public void TestRateLimiterWontReturnImpossiblyLongWaitTime()
+        {
+            var timeSource = new TimeSourceAdjustable(0);
+            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1e-9, 1e10, 6.0, timeSource);
+
+            Assert.AreEqual(RateLimiterConstants.WaitImpossible, rateLimiter.WaitTimeForAmount(1e9));
+        }
+    }
+
+
+    class TimeSourceZero : ITimeSource
+    {
+        public long CurrentTimeTicks()
+        {
+            return 0L;
+        }
+    }
+    
+    class TimeSourceAdjustable : ITimeSource
+    {
+
+        public TimeSourceAdjustable(long startTime = 0L)
+        {
+            _currentTime = startTime;
+        }
+
+        public long CurrentTimeTicks()
+        {
+            return _currentTime;
+        }
+
+        public void AddTimeTicks(long ticks)
+        {
+            _currentTime += ticks;
+        }
+
+        public void SetTime(long ticks)
+        {
+            _currentTime = ticks;
+        }
+        
+        private long _currentTime;
+    }
+}

--- a/RateLimiterTests/TestRateLimiter.cs
+++ b/RateLimiterTests/TestRateLimiter.cs
@@ -37,31 +37,7 @@ namespace RateLimiterTests
             Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount(1.0));
             Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount());
         }
-        
-        /*
-        [TestMethod]
-        public void TestRateLimiterCreateWorksWithoutTimeSource()
-        {
-            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 0.0);
-            
-            Assert.IsNotNull(rateLimiter);
-            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount(1.0));
-            Assert.IsTrue(TicksPerSecond(1) >= rateLimiter.WaitTimeForAmount());
-            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount(1.0));
-            Assert.IsTrue(TicksPerSecond(0.95) <= rateLimiter.WaitTimeForAmount());
-        }
 
-        [TestMethod]
-        public void TestRateLimiterCreateWorksWithTimeSource()
-        {
-            var rateLimiter = RateLimiterTokenBucket.CreateInstance(1.0, 5.0, 0.0, new TimeSourceZero());
-            
-            Assert.IsNotNull(rateLimiter);
-            Assert.AreEqual(TicksPerSecond(1), rateLimiter.WaitTimeForAmount(1.0));
-            Assert.AreEqual(TicksPerSecond(1), rateLimiter.WaitTimeForAmount());
-        }
-        */
-        
         [TestMethod]
         public void TestRateLimiterGivesOutInitAmount()
         {

--- a/RateLimiterTests/TestRateLimiter.cs
+++ b/RateLimiterTests/TestRateLimiter.cs
@@ -8,13 +8,10 @@ namespace RateLimiterTests
     [TestClass]
     public class TestRateLimiter
     {
-        // Number of 100ns ticks per time unit (copied from DateTime)
-        private const long S_TicksPerMillisecond = 10000;
-        private const long S_TicksPerSecond = S_TicksPerMillisecond * 1000;
 
         private long TicksPerSecond(double seconds)
         {
-            return (long) Math.Ceiling(seconds * (double)S_TicksPerSecond);
+            return (long) Math.Ceiling(seconds * (double)TimeSpan.TicksPerSecond);
         }
 
         [TestMethod]

--- a/RateLimiterTests/TimeSourceAdjustable.cs
+++ b/RateLimiterTests/TimeSourceAdjustable.cs
@@ -1,0 +1,30 @@
+using RateLimiter;
+
+namespace RateLimiterTests
+{
+    class TimeSourceAdjustable : ITimeSource
+    {
+
+        public TimeSourceAdjustable(long startTime = 0L)
+        {
+            _currentTime = startTime;
+        }
+
+        public long CurrentTimeTicks()
+        {
+            return _currentTime;
+        }
+
+        public void AddTimeTicks(long ticks)
+        {
+            _currentTime += ticks;
+        }
+
+        public void SetTime(long ticks)
+        {
+            _currentTime = ticks;
+        }
+        
+        private long _currentTime;
+    }
+}

--- a/RateLimiterTests/TimeSourceZero.cs
+++ b/RateLimiterTests/TimeSourceZero.cs
@@ -1,0 +1,12 @@
+using RateLimiter;
+
+namespace RateLimiterTests
+{
+    class TimeSourceZero : ITimeSource
+    {
+        public long CurrentTimeTicks()
+        {
+            return 0L;
+        }
+    }
+}

--- a/rate-limiter-dotnet.sln
+++ b/rate-limiter-dotnet.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiter", "RateLimiter\RateLimiter.csproj", "{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RateLimiterTests", "RateLimiterTests\RateLimiterTests.csproj", "{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|x64.Build.0 = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Debug|x86.Build.0 = Debug|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|x64.ActiveCfg = Release|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|x64.Build.0 = Release|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|x86.ActiveCfg = Release|Any CPU
+		{CDEF4AB6-7DD5-4D9C-A5D7-CED5F9DCF72E}.Release|x86.Build.0 = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|x64.Build.0 = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E919F9D-B4FB-4A7A-93EB-C35E0C5B5F42}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Initial Version -- just the rate limiting, no support for persistence or synchronization.

Main Implementation closely follows Java version, main differences:

- overloads replaced with default params
- use ticks instead of milliseconds
- tests were restructured a bit, driven by code coverage

Java Version for reference: https://github.com/hn3000/rate-limiter-java/